### PR TITLE
Add stacktrace to plugsnag

### DIFF
--- a/lib/plugsnag.ex
+++ b/lib/plugsnag.ex
@@ -22,7 +22,7 @@ defmodule Plugsnag do
     report_error(conn, assigns, opts)
   end
 
-  defp report_error(conn, %{reason: exception}, opts) do
+  defp report_error(conn, %{reason: exception, stack: stacktrace}, opts) do
     error_report_builder =
       Keyword.get(opts, :error_report_builder, Plugsnag.BasicErrorReportBuilder)
 
@@ -30,6 +30,7 @@ defmodule Plugsnag do
       %Plugsnag.ErrorReport{}
       |> error_report_builder.build_error_report(conn)
       |> Map.from_struct()
+      |> Map.put(:stacktrace, stacktrace)
       |> Keyword.new()
 
     reporter = Application.get_env(:plugsnag, :reporter, Bugsnag)

--- a/test/plugsnag_test.exs
+++ b/test/plugsnag_test.exs
@@ -135,6 +135,20 @@ defmodule PlugsnagTest do
                id: "abc123"
              }
     end
+
+    test "includes a stacktrace" do
+      conn = conn(:get, "/")
+
+      assert_raise Plug.Conn.WrapperError, "** (PlugsnagTest.TestException) oops", fn ->
+        TestPlug.call(conn, [])
+      end
+
+      assert_received {:report, {%TestException{}, options}}
+
+      stacktrace = Keyword.get(options, :stacktrace)
+      # We'll just test that the stacktrace is not nil and that the key exists
+      assert is_list(stacktrace)
+    end
   end
 
   describe "4xx exception" do


### PR DESCRIPTION
* Add the stacktrace provided by Plug.ErrorHandler to the options sent to the reporter.